### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "main.py"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # PyCash
 a barebones check registry tool
 
+(try it out!)
+[![Run on Repl.it](https://repl.it/badge/github/ydissac/PyCash)](https://repl.it/github/ydissac/PyCash)
 
 # Requirements: 
 python and less


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).